### PR TITLE
feat: add React Query Devtools for improved debugging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@radix-ui/react-slot": "^1.1.2",
         "@radix-ui/react-switch": "^1.1.3",
         "@tanstack/react-query": "^5.66.9",
+        "@tanstack/react-query-devtools": "^5.67.3",
         "@types/js-cookie": "^3.0.6",
         "axios": "^1.8.1",
         "class-variance-authority": "^0.7.1",
@@ -1687,26 +1688,51 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.67.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.67.1.tgz",
-      "integrity": "sha512-AkFmuukVejyqVIjEQoFhLb3q+xHl7JG8G9cANWTMe3s8iKzD9j1VBSYXgCjy6vm6xM8cUCR9zP2yqWxY9pTWOA==",
+      "version": "5.67.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.67.3.tgz",
+      "integrity": "sha512-pq76ObpjcaspAW4OmCbpXLF6BCZP2Zr/J5ztnyizXhSlNe7fIUp0QKZsd0JMkw9aDa+vxDX/OY7N+hjNY/dCGg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.67.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.67.2.tgz",
+      "integrity": "sha512-O4QXFFd7xqp6EX7sdvc9tsVO8nm4lpWBqwpgjpVLW5g7IeOY6VnS/xvs/YzbRhBVkKTMaJMOUGU7NhSX+YGoNg==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.67.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.67.1.tgz",
-      "integrity": "sha512-fH5u4JLwB6A+wLFdi8wWBWAYoJV5deYif2OveJ26ktAWjU499uvVFS1wPWnyEyq5LvZX1MZInvv9QRaIZANRaQ==",
+      "version": "5.67.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.67.3.tgz",
+      "integrity": "sha512-u/n2HsQeH1vpZIOzB/w2lqKlXUDUKo6BxTdGXSMvNzIq5MHYFckRMVuFABp+QB7RN8LFXWV6X1/oSkuDq+MPIA==",
       "dependencies": {
-        "@tanstack/query-core": "5.67.1"
+        "@tanstack/query-core": "5.67.3"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.67.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.67.3.tgz",
+      "integrity": "sha512-+PM2UnCyXAQozXB32cnawx38wwnaHPTtFAhX1V5QmHy/FL1u9k7nd8nxn2+GTwf15SGbUaGfxA/vq/9EARUEIQ==",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.67.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.67.3",
         "react": "^18 || ^19"
       }
     },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-switch": "^1.1.3",
     "@tanstack/react-query": "^5.66.9",
+    "@tanstack/react-query-devtools": "^5.67.3",
     "@types/js-cookie": "^3.0.6",
     "axios": "^1.8.1",
     "class-variance-authority": "^0.7.1",

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -4,6 +4,7 @@ import { ReactNode, useEffect, useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { SessionProvider } from "next-auth/react";
 import { ThemeProvider } from "next-themes";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 export function Providers({ children }: { children: ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
@@ -29,6 +30,7 @@ export function Providers({ children }: { children: ReactNode }) {
           {children}
         </ThemeProvider>
       </SessionProvider>
+      <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );
 }


### PR DESCRIPTION
Add `@tanstack/react-query-devtools` to the project dependencies and 
integrate it into the `Providers` component. This change enhances 
development by providing a visual interface for inspecting and 
debugging React Query states, improving the overall developer 
experience. Update the version of `@tanstack/react-query` to 
ensure compatibility with the latest features.