### PR TITLE
fix(api): ensure window object exists before redirecting

### DIFF
--- a/src/shared/api/api.ts
+++ b/src/shared/api/api.ts
@@ -33,7 +33,9 @@ api.interceptors.response.use(
         await signOut({ redirect: true, callbackUrl: "/auth/login" });
       } catch (signOutError) {
         console.error("Error during sign out:", signOutError);
-        window.location.href = "/auth/login";
+        if (typeof window !== "undefined") {
+          window.location.href = "/auth/login";
+        }
       }
     }
     return Promise.reject(error);

--- a/src/shared/config/next-auth/options.ts
+++ b/src/shared/config/next-auth/options.ts
@@ -95,18 +95,6 @@ export const authOptions: AuthOptions = {
       }
     },
   },
-  events: {
-    async signOut({}: { token: JWT }) {
-      try {
-        await fetch("/api/auth/signout", {
-          method: "POST",
-          credentials: "include",
-        });
-      } catch (error) {
-        console.error("Error during signout:", error);
-      }
-    },
-  },
   session: {
     strategy: "jwt" as SessionStrategy,
     maxAge: 24 * 60 * 60, // 24 hours


### PR DESCRIPTION
Check for the existence of the window object before 
redirecting to the login page after a sign-out error. 
This prevents potential runtime errors in non-browser 
environments. Remove unused signOut event handler 
from the auth options to streamline the code.