### PR TITLE
feat: update category actual time on task changes

### DIFF
--- a/src/entities/categories/model/category.model.ts
+++ b/src/entities/categories/model/category.model.ts
@@ -3,6 +3,7 @@ export interface UpdateCategoryDTO {
   changes: {
     name?: string;
     plannedTime?: number;
+    actualTime?: number;
   };
 }
 export interface Category {

--- a/src/entities/categories/ui/TaskCategories.tsx
+++ b/src/entities/categories/ui/TaskCategories.tsx
@@ -11,6 +11,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { useMemo } from "react";
 
 interface TaskCategoriesProps {
   categories: Category[];
@@ -30,6 +31,12 @@ export function TaskCategories({
   onDeleteCategory,
   isLoading,
 }: TaskCategoriesProps) {
+  const sortedCategories = useMemo(() => {
+    return [...categories].sort(
+      (a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt)
+    );
+  }, [categories]);
+
   return (
     <div className="border border-border p-4 rounded-md shadow-sm bg-card">
       <h2 className="font-semibold mb-4 text-xl text-foreground">
@@ -65,7 +72,7 @@ export function TaskCategories({
             </TableRow>
           </TableHeader>
           <TableBody>
-            {categories.map((category) => (
+            {sortedCategories.map((category) => (
               <TableRow key={category.id} className="group">
                 <TableCell>
                   <div


### PR DESCRIPTION
Add a new function to update the actual time of categories when tasks 
are created, updated, or unarchived. Refactor the category time update 
logic to use a single method for consistency. Update relevant comments 
and ensure the UI reflects sorted categories. This improves the 
accuracy of category time tracking and enhances code maintainability.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #16 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #14 
<!-- GitButler Footer Boundary Bottom -->

